### PR TITLE
Fix typo in height description

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -32,7 +32,7 @@ from typing import List, Optional
 
 class UserData(BaseModel):
     weight: float = Field(..., description="Peso del usuario en Kilogramos")
-    height: float = Field(..., description="Altura del usuario en centimentros")
+    height: float = Field(..., description="Altura del usuario en centímetros")
     age: int = Field(..., description="Edad del usuario")
     gender: str = Field(..., pattern="^(male|female)$", description="Genero del usuario, 'Masculino' o 'Femenino'")
     activity_level: str = Field(..., pattern="^(sedentary|lightly_active|moderately_active|very_active|super_active)$", description="Activity level")


### PR DESCRIPTION
## Summary
- minor fix to description for `height` in `UserData`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840e42004b483279916ba609328e0f5