### PR TITLE
Add endpoint test and requirements

### DIFF
--- a/backend/tests/test_generate_plan.py
+++ b/backend/tests/test_generate_plan.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+def test_generate_plan_success():
+    payload = {
+        "weight": 70,
+        "height": 175,
+        "age": 30,
+        "gender": "male",
+        "activity_level": "lightly_active",
+        "goals": ["Perder peso"],
+        "routine_preference": "Ejercicio en casa",
+        "dietary_restrictions": []
+    }
+    response = client.post("/generate_plan/", json=payload)
+    assert response.status_code == 200
+    json_data = response.json()
+    assert "exercise_plan" in json_data
+    assert "nutrition_plan" in json_data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+pydantic
+scikit-learn
+joblib
+pytest
+httpx


### PR DESCRIPTION
## Summary
- add pytest test for `/generate_plan/`
- list backend and testing requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6840e48c3ae483279e3efc74444e30c1