### PR TITLE
Use dotenv for JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# NutrIA
+
+This repository contains the backend and frontend code for the NutrIA application.
+
+## Environment Variables
+
+The backend requires a `.env` file in the project root with the following variable:
+
+```
+JWT_SECRET=<your_jwt_secret>
+```
+
+`JWT_SECRET` is used to sign JSON Web Tokens for authentication.

--- a/backend/server.mjs
+++ b/backend/server.mjs
@@ -3,12 +3,15 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import bodyParser from 'body-parser';
 import cors from 'cors';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
 // Clave secreta para firmar el token.
-const JWT_SECRET = 'your_jwt_secret_key';
+const JWT_SECRET = process.env.JWT_SECRET;
 
 app.use(cors());
 app.use(bodyParser.json());

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "cors": "^2.8.5",
     "express": "^4.21.1",
     "jsonwebtoken": "^9.0.2",
+    "dotenv": "^16.4.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0"


### PR DESCRIPTION
## Summary
- enable dotenv in server.mjs
- load JWT secret from `.env`
- document `.env` variable
- add dotenv to dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4db92008327a48556683100dfac