### PR TITLE
Add SQLAlchemy DB and update plan endpoints

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,21 @@
+from sqlalchemy import create_engine, Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "sqlite:///./plans.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+class Plan(Base):
+    __tablename__ = "plans"
+
+    id = Column(Integer, primary_key=True, index=True)
+    data = Column(Text)
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+sqlalchemy

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -54,9 +54,18 @@ const App = () => {
         setCurrentDay(null); // Volver a la vista general después de completar un día
     };
 
-    const handleDeletePlan = () => {
-        setPlan(null);
-        setHasPlan(false);
+    const handleDeletePlan = async () => {
+        try {
+            await fetch('http://127.0.0.1:8000/api/reset-plan', {
+                method: 'POST',
+                headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
+            });
+        } catch (error) {
+            console.error('Error al eliminar el plan:', error);
+        } finally {
+            setPlan(null);
+            setHasPlan(false);
+        }
     };
 
     return (

--- a/frontend/src/components/Form.js
+++ b/frontend/src/components/Form.js
@@ -80,14 +80,20 @@ const Form = ({ setPlan, setHasPlan }) => {
       };
 
       try {
-        const response = await axios.post('http://localhost:8000/generate_plan/', userData);
+        const response = await axios.post(
+          'http://localhost:8000/generate_plan/',
+          userData,
+          {
+            headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
+          }
+        );
         setPlan(response.data);
         setHasPlan(true); // Actualiza hasPlan a true
-    } catch (error) {
+      } catch (error) {
         console.error('Error al obtener el plan:', error);
+      }
     }
-}
-};
+  };
 
   const handleCheckboxChange = (setState, value, state) => {
     if (state.includes(value)) {


### PR DESCRIPTION
## Summary
- setup SQLAlchemy database in backend
- store generated plans in DB and expose through API
- call API from React app for saving/deleting plans
- add backend requirements file

## Testing
- `python -m py_compile backend/main.py`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4f0b6208327a70f863b99a022c1