### PR TITLE
Add dependency list and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# NutrIA
+
+This repository contains the backend and frontend for the NutrIA project.
+
+## Installing Python dependencies
+
+Use `pip` to install the required backend packages listed in `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+If you prefer to install them individually, run:
+
+```bash
+pip install fastapi uvicorn pydantic scikit-learn pandas numpy joblib
+```

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,0 +1,12 @@
+# dependencies.py
+
+# List of required Python packages for the backend
+REQUIRED_PACKAGES = [
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+    "scikit-learn",
+    "pandas",
+    "numpy",
+    "joblib",
+]


### PR DESCRIPTION
## Summary
- add README with instructions on installing Python packages
- declare required packages in backend/dependencies.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6840e6ce858483279f25b9086027b299